### PR TITLE
0.3 Mod Support

### DIFF
--- a/BinToInst.cpp
+++ b/BinToInst.cpp
@@ -1,14 +1,5 @@
 #include "mainwindow.h"
 
-QString reverse_input(QString input) {
-    QString pt1 = input.mid(0, 8);
-    QString pt2 = input.mid(8, 8);
-    QString pt3 = input.mid(16, 8);
-    QString pt4 = input.mid(24, 8);
-    QString output = pt4 + pt3 + pt2 + pt1;
-    return output;
-}
-
 QString GGR(int regIndex){
     //Get General Register
     QString retReg = genRegList[regIndex];
@@ -355,7 +346,7 @@ inline QString MMI_inst(int setlist[]) {
 
 QString MainWindow::convToInstruction(QString input) {
     //refer to page 370 of the EE core instruction manual
-    input = reverse_input(input);
+    input = reverse_input(input, 8);
     QString set1 = input.mid(0,6);
     QString set2 = input.mid(6,5);
     QString set3 = input.mid(11,5);

--- a/MIPS_Editor.pro
+++ b/MIPS_Editor.pro
@@ -14,7 +14,8 @@ SOURCES += \
     QBinStuff.cpp \
     bufferhandler.cpp \
     main.cpp \
-    mainwindow.cpp
+    mainwindow.cpp \
+    modhandler.cpp
 
 HEADERS += \
     mainwindow.h

--- a/MIPS_Editor.pro.user
+++ b/MIPS_Editor.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.15.1, 2021-09-24T03:45:18. -->
+<!-- Written by QtCreator 4.15.1, 2021-09-24T16:06:29. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/MIPS_Editor.pro.user
+++ b/MIPS_Editor.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.15.1, 2021-09-24T16:06:29. -->
+<!-- Written by QtCreator 4.15.1, 2021-09-26T17:10:29. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/QBinStuff.cpp
+++ b/QBinStuff.cpp
@@ -1,5 +1,16 @@
 #include "mainwindow.h"
 
+QString MainWindow::reverse_input(QString input, int unitLength) {
+    QString part;
+    QString output = "";
+    int bytes = int(input.length()/unitLength);
+    for (int i = bytes; i >= 0; --i){
+        part = input.mid(i*unitLength, unitLength);
+        output += part;
+    }
+    return output;
+}
+
 QString hex_char_to_bin(QChar c)
 {
     switch (c.toUpper().unicode())
@@ -34,4 +45,44 @@ QString MainWindow::hex_to_bin(QByteArray arrhex)
         bin += binhex;
     }
     return bin;
+}
+
+qint64 MainWindow::byteWrite( QFile& file, int8_t var ) {
+  qint64 toWrite = sizeof(decltype (var));
+  qint64  written = file.write(reinterpret_cast<const char*>(&var), toWrite);
+  if (written != toWrite) {
+    qDebug () << "write error";
+  }
+   //qDebug () << "out: " << written;
+  return written;
+}
+
+qint64 MainWindow::shortWrite( QFile& file, int16_t var ) {
+  qint64 toWrite = sizeof(decltype (var));
+  qint64 written = file.write(reinterpret_cast<const char*>(&var), toWrite);
+  if (written != toWrite) {
+    qDebug () << "write error";
+  }
+   //qDebug () << "out: " << written;
+  return written;
+}
+
+qint64 MainWindow::intWrite( QFile& file, int32_t var ) {
+  qint64 toWrite = sizeof(decltype (var));
+  qint64  written = file.write(reinterpret_cast<const char*>(&var), toWrite);
+  if (written != toWrite) {
+    qDebug () << "write error";
+  }
+   //qDebug () << "out: " << written;
+  return written;
+}
+
+qint64 MainWindow::longWrite( QFile& file, int64_t var ) {
+  qint64 toWrite = sizeof(decltype (var));
+  qint64  written = file.write(reinterpret_cast<const char*>(&var), toWrite);
+  if (written != toWrite) {
+    qDebug () << "write error";
+  }
+   //qDebug () << "out: " << written;
+  return written;
 }

--- a/bufferhandler.cpp
+++ b/bufferhandler.cpp
@@ -98,7 +98,7 @@ void MainWindow::handleInsert(){
         //ex 10000001 00000000 00000000 00000001 -> 129 0 0 1 -> loop to convert each to bytearray then combine them
         if (radioInst->isChecked()){
             convReturn = convFromInst(entry);
-            MainWindow::filebuffer.insert(numselectaddress, convReturn);
+            filebuffer.insert(numselectaddress, convReturn);
             updateFileBuffer();
             ButtonInsert->setText("Inserted");
             ButtonInsert->resize(100,30);
@@ -108,7 +108,7 @@ void MainWindow::handleInsert(){
             for (int k = 0; k <4; ++k){
                 revReturn += convReturn.mid(3-k, 1);
             }
-            MainWindow::filebuffer.insert(numselectaddress, revReturn);
+            filebuffer.insert(numselectaddress, revReturn);
             updateFileBuffer();
             ButtonInsert->setText("Inserted");
             ButtonInsert->resize(100,30);
@@ -123,6 +123,6 @@ void MainWindow::handleDelete(){
     qDebug() << selection;
     QString selectaddress = selection.left(8);
     int numselectaddress = selectaddress.toInt(nullptr, 16) - addressOffset;
-    MainWindow::filebuffer.replace(numselectaddress, 4, "");
+    filebuffer.replace(numselectaddress, 4, "");
     updateFileBuffer();
 }

--- a/bufferhandler.cpp
+++ b/bufferhandler.cpp
@@ -59,24 +59,19 @@ void MainWindow::updateWindowBuffer(){
 }
 
 void MainWindow::loadFile(){
-    /*QString entry = userInPath -> text();
+    QString entry = QFileDialog::getOpenFileName(this, tr("Select ELF"), QDir::currentPath(), tr("All Files (*.*)"));
     if (entry.length() != 0){
         fileInPath = entry;
         QFile filein(fileInPath);
         if (!filein.open(QIODevice::ReadOnly)) return;
         filebuffer = filein.readAll();
         updateFileBuffer();
-    }*/
-    QFile filein(fileInPath);
-    if (!filein.open(QIODevice::ReadOnly)) return;
-    filebuffer = filein.readAll();
-    //filebuffer = filein.read(6088572);
-    updateFileBuffer();
+    }
 
 }
 
 void MainWindow::saveFile(){
-    QString entry = userOutPath -> text();
+    QString entry = QFileDialog::getSaveFileName(this, tr("Save ELF"), QDir::currentPath(), tr("Binary File (*.bin)"));
     if (entry.length() != 0){
         fileOutPath = entry;
         QFile fileout(fileOutPath);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -43,8 +43,17 @@ MainWindow::MainWindow(QWidget *parent)
     InstructionBox -> setGeometry(QRect(QPoint(440,50), QSize(300,30)));
     ButtonDelete = new QPushButton("Delete", this);
     ButtonDelete -> setGeometry(QRect(QPoint(540,90), QSize(100,30)));
+    radioHex = new QRadioButton("Hex view", this);
+    radioHex -> setGeometry(QRect(QPoint(440,120), QSize(100,30)));
+    radioInst = new QRadioButton("Instruction view", this);
+    radioInst -> setGeometry(QRect(QPoint(540,120), QSize(120,30)));
+    radioInst-> toggle();
+
+
     ButtonSettings = new QPushButton("Settings", this);
     ButtonSettings -> setGeometry(QRect(QPoint(540,190), QSize(100,30)));
+
+
     ButtonLoad = new QPushButton("Load", this);
     ButtonLoad -> setGeometry(QRect(QPoint(540,250), QSize(100,30)));
     ButtonExport = new QPushButton("Save", this);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -34,6 +34,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->setupUi(this);
     int longScroll = 64;
     int shortScroll = 16;
+    addressOffset = 0;
 
     SettingsWindow = new QWidget();
 
@@ -55,9 +56,15 @@ MainWindow::MainWindow(QWidget *parent)
 
 
     ButtonLoad = new QPushButton("Load", this);
-    ButtonLoad -> setGeometry(QRect(QPoint(540,250), QSize(100,30)));
+    ButtonLoad -> setGeometry(QRect(QPoint(500,250), QSize(100,30)));
     ButtonExport = new QPushButton("Save", this);
-    ButtonExport -> setGeometry(QRect(QPoint(540,280), QSize(100,30)));
+    ButtonExport -> setGeometry(QRect(QPoint(500,280), QSize(100,30)));
+
+    ButtonLoadMods = new QPushButton("Load Mods", this);
+    ButtonLoadMods -> setGeometry(QRect(QPoint(610,250), QSize(100,30)));
+    ButtonSaveMod = new QPushButton("Save Mod", this);
+    ButtonSaveMod -> setGeometry(QRect(QPoint(610,280), QSize(100,30)));
+
     MipsWindow = new QTextBrowser(this);
     MipsWindow -> setGeometry(QRect(QPoint(50,50), QSize(300,500)));
     MipsWindow->setText(MipsBuffer);
@@ -73,6 +80,14 @@ MainWindow::MainWindow(QWidget *parent)
     AddressBox -> setGeometry(QRect(QPoint(350,250), QSize(75,30)));
     ButtonAddress = new QPushButton("Jump", this);
     ButtonAddress -> setGeometry(QRect(QPoint(425,250), QSize(50,30)));
+
+    TableMods = new QTableWidget(1, 2, this);
+    TableMods -> setGeometry(QRect(QPoint(400,350), QSize(225,180)));
+    QStringList columnNames = {"Address Start", "Address End"};
+    TableMods -> setHorizontalHeaderLabels(columnNames);
+
+    connect(TableMods, SIGNAL(cellChanged(int,int)), this, SLOT(checkTable(int,int)));
+
     connect(MipsWindow, &QTextBrowser::cursorPositionChanged, this, &MainWindow::handleSelect);
     connect(ButtonDelete, &QPushButton::released, this, &MainWindow::handleDelete);
     connect(ButtonInsert, &QPushButton::released, this, &MainWindow::handleInsert);
@@ -85,6 +100,9 @@ MainWindow::MainWindow(QWidget *parent)
     connect(Button1Up, &QPushButton::released, [this, shortScroll]{MainWindow::scrollMips(-shortScroll);});
     connect(Button1Down, &QPushButton::released, [this, shortScroll]{MainWindow::scrollMips(shortScroll);});
     connect(ButtonAddress, &QPushButton::released, this, &MainWindow::jumpAddress);
+
+    connect(ButtonSaveMod, &QPushButton::released, this, &MainWindow::makeModList);
+    connect(ButtonLoadMods, &QPushButton::released, this, &MainWindow::loadModList);
 }
 
 MainWindow::~MainWindow()
@@ -120,5 +138,15 @@ void MainWindow::jumpAddress(){
     }
     else {
         qDebug() << "Not a valid address.";
+    }
+}
+
+void MainWindow::checkTable(int row, int column){
+    //should probably check for a valid address here, give user an error on invalid, and clear the cell
+    //qDebug() << "row: " << row << " column " << column;
+    if (row+1 == TableMods->rowCount()){
+        if(column+1 == TableMods->columnCount()){
+            TableMods->insertRow(row+1);
+        }
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -73,14 +73,6 @@ MainWindow::MainWindow(QWidget *parent)
     AddressBox -> setGeometry(QRect(QPoint(350,250), QSize(75,30)));
     ButtonAddress = new QPushButton("Jump", this);
     ButtonAddress -> setGeometry(QRect(QPoint(425,250), QSize(50,30)));
-    userInPath = new QLineEdit(this);
-    userInPath -> setGeometry(QRect(QPoint(500,350), QSize(180,30)));
-    userOutPath = new QLineEdit(this);
-    userOutPath -> setGeometry(QRect(QPoint(500,380), QSize(180,30)));
-    labelPathIn = new QLabel("Load file path: ", this);
-    labelPathIn -> setGeometry(QRect(QPoint(400,350), QSize(90,30)));
-    labelPathOut = new QLabel("Save file path: ", this);
-    labelPathOut -> setGeometry(QRect(QPoint(400,380), QSize(90,30)));
     connect(MipsWindow, &QTextBrowser::cursorPositionChanged, this, &MainWindow::handleSelect);
     connect(ButtonDelete, &QPushButton::released, this, &MainWindow::handleDelete);
     connect(ButtonInsert, &QPushButton::released, this, &MainWindow::handleInsert);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -16,6 +16,7 @@
 #include <QDataStream>
 #include <QBitArray>
 #include <QIODevice>
+#include <QRadioButton>
 
 #include <iostream>
 #include <stdio.h>
@@ -57,6 +58,7 @@ private slots:
     QByteArray convFromInst(QString instruction);
 
 private:
+    long long addressOffset;
     int BufferStart;
     Ui::MainWindow *ui;
 
@@ -88,6 +90,9 @@ private:
     QString fileInPath;
     QString fileOutPath;
     QPushButton ButtonUpdateSettings;
+
+    QRadioButton *radioInst;
+    QRadioButton *radioHex;
 };
 
 /*class SettingsWindow : public QWidget {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -17,6 +17,7 @@
 #include <QBitArray>
 #include <QIODevice>
 #include <QRadioButton>
+#include <QFileDialog>
 
 #include <iostream>
 #include <stdio.h>
@@ -53,6 +54,8 @@ private slots:
     void scrollMips(int amount);
     void saveFile();
     void jumpAddress();
+    void loadModList();
+    void makeModList();
     QString convToInstruction(QString input);
     QString hex_to_bin(QByteArray arrhex);
     QByteArray convFromInst(QString instruction);
@@ -83,10 +86,6 @@ private:
     QByteArray WindowBuffer;
     QString addresslist[128];
     QString linelist[64];
-    QLabel *labelPathIn;
-    QLabel *labelPathOut;
-    QLineEdit *userInPath;
-    QLineEdit *userOutPath;
     QString fileInPath;
     QString fileOutPath;
     QPushButton ButtonUpdateSettings;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -18,6 +18,8 @@
 #include <QIODevice>
 #include <QRadioButton>
 #include <QFileDialog>
+#include <QTableWidget>
+#include <QTableWidgetItem>
 
 #include <iostream>
 #include <stdio.h>
@@ -56,9 +58,15 @@ private slots:
     void jumpAddress();
     void loadModList();
     void makeModList();
+    void checkTable(int row, int column);
+    QString reverse_input(QString input, int unitLength);
     QString convToInstruction(QString input);
     QString hex_to_bin(QByteArray arrhex);
     QByteArray convFromInst(QString instruction);
+    qint64 byteWrite( QFile& file, int8_t var );
+    qint64 shortWrite( QFile& file, int16_t var );
+    qint64 intWrite( QFile& file, int32_t var );
+    qint64 longWrite( QFile& file, int64_t var );
 
 private:
     long long addressOffset;
@@ -89,6 +97,10 @@ private:
     QString fileInPath;
     QString fileOutPath;
     QPushButton ButtonUpdateSettings;
+
+    QTableWidget *TableMods;
+    QPushButton *ButtonSaveMod;
+    QPushButton *ButtonLoadMods;
 
     QRadioButton *radioInst;
     QRadioButton *radioHex;


### PR DESCRIPTION
This update brings a number of changes:
1. Loading and saving a file is now done with file dialog windows. This was super simple and should probably have been done from the start.
2. Minor upgrades to some sections of the code, for example moving reverse_input to QBinStuff to be used anywhere. 
3. Mod support. Mod files are small binary files that contain changes made to the actual code of an ELF that allow a user to make and share small changes with ease. For example, for a simple quality of life mod that only changes 20 lines of code, the modder only needs to send a <1KB file that the user can apply instead of the entire ELF file. This also allows for more mix-and-matching of mods. Multiple mods can be applied at once. 

Additional updates needed:
- Check for mod compatibility. If two mods overwrite the same section of code, this can lead to unintended behavior. There is currently not a check for this situation.
- Can't change the length of the file. This is still an overarching issue and one of the main upgrades to be made before 1.0. When this becomes possible, the mod system will need to update the adjust mod addresses as the addresses of the main ELF change.